### PR TITLE
Emit start after WebSocket is ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ class Bot extends EventEmitter {
              this.ims = data.ims;
              this.groups = data.groups;
 
-             this.emit('start');
-
              this.connect();
+             
+             this.emit('start');
          }).fail((data) => {
              this.emit('error', new Error(data.error ? data.error : data));
          }).done();


### PR DESCRIPTION
It was impossible to make a clean hook into WebSocket object in the start event handler. This patch corrects the behavior and allows hooking into the WebSocket object in the start event handler.